### PR TITLE
Update main.css, Fix mobile view

### DIFF
--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -16,7 +16,8 @@
 		border-bottom-width: 10px;
 	}
 	main {
-		@apply text-base sm:text-lg
+		@apply text-base sm:text-lg;
+		overflow-x: hidden;
 	}
 	footer {
 		@apply relative pt-7 px-4 pb-14 border-solid border-green-light;


### PR DESCRIPTION
Da pixel-box-img.svg im main-Element nach rechts versetzt sind, kommt der Fehler zustande. Die Änderung fixt gleichzeitig auch das div.back-to-top Element in der mobilen Ansicht.